### PR TITLE
Update CSRF_TRUSTED_ORIGINS to use a list for environment variable configuration

### DIFF
--- a/trivia_project/settings.py
+++ b/trivia_project/settings.py
@@ -28,7 +28,7 @@ DEBUG = config('DJANGO_DEBUG', default=False, cast=bool)
 
 ALLOWED_HOSTS = config('DJANGO_ALLOWED_HOSTS', default='').split(',')
 
-CSRF_TRUSTED_ORIGINS = config('DJANGO_CSRF_TRUSTED_ORIGINS', default='').split(',')
+CSRF_TRUSTED_ORIGINS = [config('DJANGO_CSRF_TRUSTED_ORIGINS')]
 
 # Application definition
 


### PR DESCRIPTION
Refactor the CSRF_TRUSTED_ORIGINS setting to utilize a list for better environment variable handling.